### PR TITLE
build: install vs 2017 components

### DIFF
--- a/.github/scripts/install-vs-components.ps1
+++ b/.github/scripts/install-vs-components.ps1
@@ -1,0 +1,17 @@
+Set-Location "C:\Program Files (x86)\Microsoft Visual Studio\Installer\"
+$InstallPath = "C:\Program Files\Microsoft Visual Studio\2022\Enterprise"
+$componentsToInstall= @(
+"Microsoft.VisualStudio.Component.VC.v141.x86.x64"
+"Microsoft.VisualStudio.Component.VC.v141.x86.x64.Spectre"
+"Microsoft.VisualStudio.Component.VC.v141.MFC"
+"Microsoft.VisualStudio.Component.VC.v141.MFC.Spectre"
+"Microsoft.VisualStudio.Component.VC.14.39.17.9.x86.x64"
+"Microsoft.VisualStudio.Component.VC.14.39.17.9.x86.x64.Spectre"
+"Microsoft.VisualStudio.Component.VC.14.39.17.9.MFC"
+"Microsoft.VisualStudio.Component.VC.14.39.17.9.ATL"
+)
+[string]$workloadArgs = $componentsToInstall | ForEach-Object {" --add " +  $_}
+$Arguments = ('/c', "vs_installer.exe", 'modify', '--installPath', "`"$InstallPath`"",$workloadArgs, '--quiet', '--norestart', '--nocache')
+# should be run twice
+$process = Start-Process -FilePath cmd.exe -ArgumentList $Arguments -Wait -PassThru -WindowStyle Hidden
+$process = Start-Process -FilePath cmd.exe -ArgumentList $Arguments -Wait -PassThru -WindowStyle Hidden

--- a/.github/workflows/msbuild.yml
+++ b/.github/workflows/msbuild.yml
@@ -32,6 +32,9 @@ jobs:
 
     - name: Add MSBuild to PATH
       uses: microsoft/setup-msbuild@v1.3.1
+    
+    - name: Install components
+      run: .\.github\scripts\install-vs-components.ps1
 
     - name: Restore NuGet packages
       working-directory: ${{env.GITHUB_WORKSPACE}}


### PR DESCRIPTION
builds start failing as MS decides to remove older components from Visual Studio runner image
https://github.com/actions/runner-images/issues/9701

So we need to install them before building our job

- Install Visual C++ Components