### PR TITLE
Remove deprecated reviewers Dependabot config option

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,17 +4,11 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
-    reviewers:
-      - abhijeetnarvekar
   - package-ecosystem: "nuget"
     directory: "/Acrolinx.Adapter.Demo.Sidebar.Cpp/"
     schedule:
       interval: "daily"
-    reviewers:
-      - abhijeetnarvekar
   - package-ecosystem: "nuget"
     directory: "/Acrolinx.Demo.Sidebar.Cpp/"
     schedule:
       interval: "daily"
-    reviewers:
-      - abhijeetnarvekar


### PR DESCRIPTION
See https://github.blog/changelog/2025-04-29-dependabot-reviewers-configuration-option-being-replaced-by-code-owners/